### PR TITLE
Fix potential naming conflict by aliasing Image library

### DIFF
--- a/lib/Scandio/lmvc/modules/assetpipeline/assetpipes/ImagePipe.php
+++ b/lib/Scandio/lmvc/modules/assetpipeline/assetpipes/ImagePipe.php
@@ -3,7 +3,6 @@
 namespace Scandio\lmvc\modules\assetpipeline\assetpipes;
 
 use Scandio\lmvc\LVC;
-use Intervention\Image\Image;
 
 /**
  * Class ImagePipe
@@ -35,7 +34,7 @@ class ImagePipe extends AbstractAssetPipe
     {
         $file = $this->_assetDirectory . DIRECTORY_SEPARATOR . $asset;
 
-        $img = Image::make($asset);
+        $img = \Intervention\Image\Image::make($asset);
 
         if (isset($options[0]) && isset($options[1])) {
             $img->resize($options[0], $options[1], true);


### PR DESCRIPTION
> Lost commit access to the main repository hence a pull request.

Fix aliasing `Intervention\Image\Image` within the `ImagePipe` which for me resulted in naming conflicts at run time of an application. TBH: The reason is a bit opaque to me but explicitly calling the Intervention library class fixes the issue. Furthermore, there's not draw back of doing so as it's called only once. 

Please release a new version of the `lmvc-modules` in case of a merge.

Cheers!