### PR TITLE
Fix pulling in dependencies from dev-master.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,15 +16,15 @@
 
     "require": {
         "php": ">=5.4",
-        "scandio/lmvc":"0.4.*",
-        "leafo/lessphp": "v0.3.9",
-        "mustache/mustache": "v2.1.0",
-        "leafo/scssphp": "v0.0.7",
-        "nitra/php-min": "dev-master",
-        "intervention/image": "2.0.2",
-        "coffeescript/coffeescript": "dev-master",
-        "scandio/troba": "dev-master",
-        "atelierspierrot/markdown-extended": "dev-master"
+        "scandio/lmvc":"^0.4.0",
+        "leafo/lessphp": "^0.3.9",
+        "mustache/mustache": "^2.1.0",
+        "leafo/scssphp": "^0.0.7",
+        "nitra/php-min": "^0.0.5",
+        "intervention/image": "^2.3.5",
+        "coffeescript/coffeescript": "^1.3.1",
+        "picas/markdown-extended": "dev-master",
+        "scandio/troba": "^0.5.5"
     },
     "require-dev": {
         "phpunit/phpunit": "3.7.*"

--- a/lib/Scandio/lmvc/modules/assetpipeline/assetpipes/ImagePipe.php
+++ b/lib/Scandio/lmvc/modules/assetpipeline/assetpipes/ImagePipe.php
@@ -3,6 +3,7 @@
 namespace Scandio\lmvc\modules\assetpipeline\assetpipes;
 
 use Scandio\lmvc\LVC;
+use Intervention\Image\ImageManagerStatic as Image;
 
 /**
  * Class ImagePipe
@@ -19,6 +20,8 @@ class ImagePipe extends AbstractAssetPipe
     function __construct()
     {
         parent::__construct();
+
+        //Image::configure(array('driver' => 'imagick'));
     }
 
     /**
@@ -32,12 +35,12 @@ class ImagePipe extends AbstractAssetPipe
      */
     public function process($asset, $options = [], $errors = '')
     {
-        $file = $this->_assetDirectory . DIRECTORY_SEPARATOR . $asset;
-
-        $img = \Intervention\Image\Image::make($asset);
+        $img = Image::make($asset);
 
         if (isset($options[0]) && isset($options[1])) {
-            $img->resize($options[0], $options[1], true);
+          $img->resize($options[0], $options[1], function($constraint) {
+            $constraint->aspectRatio();
+          });
         }
 
         $img->save($asset);

--- a/lib/Scandio/lmvc/modules/assetpipeline/assetpipes/MarkdownPipe.php
+++ b/lib/Scandio/lmvc/modules/assetpipeline/assetpipes/MarkdownPipe.php
@@ -30,15 +30,12 @@ class MarkdownPipe extends AbstractAssetPipe
      */
     public function process($asset, $options = [], $errors = '')
     {
-        $html = null;
         $file = $this->_assetDirectory . DIRECTORY_SEPARATOR . $asset;
+        $parser = new \MarkdownExtended\Parser();
 
-        $html = \MarkdownExtended\MarkdownExtended::create()
-           ->get('Parser', array())
-           ->parse( new \MarkdownExtended\Content(null, $file) )
-           ->getContent();
+        $content = $parser->transformSource($file);
 
-        return $html->getBody();
+        return $content->getBody();
     }
 
     /**


### PR DESCRIPTION
Dependencies have been pulled in from `dev-master` (intern mistake :smile:) for all asset pipes which broke some of them. Having breaking changes underneath them...

I pinned them to just pull in minor/feature updates hoping that the world follows semver.

Sorry to bother again and thanks! This should be the last pull request...