### PR TITLE
Fix markdown pipe due to API change in composer package

### DIFF
--- a/lib/Scandio/lmvc/modules/assetpipeline/assetpipes/MarkdownPipe.php
+++ b/lib/Scandio/lmvc/modules/assetpipeline/assetpipes/MarkdownPipe.php
@@ -30,12 +30,13 @@ class MarkdownPipe extends AbstractAssetPipe
      */
     public function process($asset, $options = [], $errors = '')
     {
+        $html = null;
         $file = $this->_assetDirectory . DIRECTORY_SEPARATOR . $asset;
-        $parser = new \MarkdownExtended\Parser();
 
-        $content = $parser->transformSource($file);
+        $html = \MarkdownExtended\MarkdownExtended::parse($file)
+           ->getContent();
 
-        return $content->getBody();
+        return $html;
     }
 
     /**


### PR DESCRIPTION
> The `picas/markdown-extended` changed its API which needs to be reflected in the `MarkdownPipe.php`.

Sadly, `picas/markdown-extended` does not seem to release in a versioned manner so this might reoccur. _|___|_  ╰(º o º╰)

Let me know if there is anything missing or faulty in this PR. Please also tag a new version after merging this in 🐱.
